### PR TITLE
feat: Implement pattern-based conditional Figma embed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,27 +1,83 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
 
 export default class FigmaEmbedPlugin extends Plugin {
-	async onload() {
-		this.registerMarkdownPostProcessor(this.figmaEmbedProcessor.bind(this));
-	}
+    async onload() {
+        // This part stays the same - it registers the post processor
+        this.registerMarkdownPostProcessor(this.figmaEmbedProcessor.bind(this));
+    }
 
-	figmaEmbedProcessor(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
-		const figmaLinks = el.querySelectorAll(
-			'a[href^="https://www.figma.com/"]'
-		);
+    /**
+     * Markdown post processor function to find Figma links and potentially embed them based on URL patterns.
+     * This version relies ONLY on pattern matching. If a URL matches a pattern, it attempts to embed.
+     * URLs not matching patterns (or matching patterns but failing to load) will remain as links.
+     *
+     * @param el - The HTML element being processed.
+     * @param ctx - The context of the markdown processing.
+     */
+    figmaEmbedProcessor(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
+        // Select all <a> tags with an href starting with the Figma domain
+        const figmaLinks = el.querySelectorAll(
+            'a[href^="https://www.figma.com/"]'
+        );
 
-		figmaLinks.forEach((link: HTMLAnchorElement) => {
-			const figmaUrl = link.href;
-			const iframe = document.createElement("iframe");
-			iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(
-				figmaUrl
-			)}`;
-			iframe.classList.add("figmaembed-iframe");
-			// iframe.style.width = "100%";
-			// iframe.style.height = "450px";
-			// iframe.style.border = "none";
+        // --- UPDATED Pattern Definition (Pattern-Only Approach) ---
+        // Define URL patterns that indicate an item *likely* to be embeddable asset
+        // by requiring at least one character *after* the main path segment slash (e.g., /file/abc).
+        // If a URL matches one of these patterns, the plugin will attempt to embed it.
+        // If a URL does NOT match these patterns, it will remain a standard text link.
+        // NOTE: This approach does NOT use the oEmbed endpoint, so it cannot
+        // reliably check if a matching link is actually embeddable (e.g., due to permissions,
+        // or if the pattern matches a page that isn't truly an embeddable asset).
+        // Matching links that aren't embeddable will result in a broken iframe.
+        const embeddablePatterns = [
+            /\/file\/[^\/]+/,   // Matches /file/ followed by one or more non-slash characters
+            /\/design\/[^\/]+/, // Matches /design/ followed by one or more non-slash characters
+            /\/proto\/[^\/]+/,  // Matches /proto/ followed by one or more non-slash characters
+            /\/board\/[^\/]+/,  // Matches /board/ followed by one or more non-slash characters
+            /\/slides\/[^\/]+/, // Matches /slides/ followed by one or more non-slash characters
+            /\/deck\/[^\/]+/,    // Matches /deck/ followed by one or more non-slash characters
+            /\/buzz\/[^\/]+/,   // Matches /buzz/ followed by one or more non-slash characters
+            /\/site\/[^\/]+/    // Matches /site/ followed by one or more non-slash characters
+        ];
 
-			link.parentNode?.replaceChild(iframe, link);
-		});
-	}
+        // Iterate over each found Figma link
+        figmaLinks.forEach((link: HTMLAnchorElement) => {
+            const figmaUrl = link.href; // Get the original URL from the link in the markdown
+
+            // Check if the original URL matches any of the defined STRICTER embeddable patterns
+            const isEmbeddableUrl = embeddablePatterns.some(pattern => pattern.test(figmaUrl));
+
+            // If the URL matches a pattern that suggests it's embeddable based on its structure
+            if (isEmbeddableUrl) {
+                // Create the iframe using the hardcoded embed URL structure.
+                // This happens unconditionally for matching links.
+                const iframe = document.createElement("iframe");
+                iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(
+                    figmaUrl
+                )}`;
+
+                // Add class and styles for the iframe
+                iframe.classList.add("figmaembed-iframe");
+                iframe.style.width = "100%";
+                iframe.style.height = "450px"; // Adjust as needed
+                iframe.style.border = "none";
+                iframe.setAttribute("allowfullscreen", "true");
+
+                // Replace the original link with the iframe
+                link.parentNode?.replaceChild(iframe, link);
+
+                // console.log(`Attempting embed for pattern match: ${figmaUrl}`); // Optional log
+            } else {
+                // If the URL does NOT match the STRICTER pattern, do nothing.
+                // It remains a standard text link instantly.
+                // This covers URLs like https://www.figma.com/buzz/ or https://www.figma.com/pricing/
+                // console.log(`Figma link does not match stricter embeddable patterns, leaving as link: ${figmaUrl}`); // Optional log
+            }
+        });
+    } // <- END of figmaEmbedProcessor content
+
+    // This part stays the same
+    async onunload() {
+        // Clean up logic if needed
+    }
 }


### PR DESCRIPTION
Hi @kocheck,

Thanks for putting together the "Figma Embed" plugin for Obsidian!

Here's a suggested improvement I've implemented and tested locally.

# Problem

The plugin tries to embed any link starting with `https://www.figma.com/` into an iframe. When in Reading view, this results in URLs for non-embeddable pages showing the message "Invalid URL" in an iframe, instead of the URL as plain text.

# Solution

This Pull Request updates the `figmaEmbedProcessor` to implement a pattern-matching check based on the URL structure.

It now only attempts to create an iframe for Figma links that match stricter URL patterns, e.g., patterns matching `/file/`, `/board/`, `/proto/`, etc. followed by an ID or patch segment like `/board/qDQm8a1756XkEsFoaSQmcd`, for example.

**Links that do not match these stricter patterns will remain as standard text links.**

# Testing

I have tested this change in my local Obsidian vault using various types of Figma links:

## Links matching patterns (attempted embed)

Tested with examples of types `file`, `board`, `proto`, `slides`, `deck`, and `buzz` links that included characters/IDs after the segment slash (e.g., https://www.figma.com/community/file/1027358830096634813/empathy-map). These links now attempt to load the embed.

## Links NOT matching stricter patterns (remain links)

Tested with non-embeddable pages like:

- https://www.figma.com/release-notes/
- https://www.figma.com/pricing/
- https://www.figma.com/buzz/
- https://www.figma.com/make/
- https://www.figma.com/sites/
- https://www.figma.com/draw/

All these links now correctly remain as standard text links instead of attempting to embed.

# Notes for Maintainer

I noticed you have a [branch](https://github.com/kocheck/obsidian-figma-viewer/tree/kyle/enhancements). where you are working on additional features (like settings). I reviewed the code there briefly and saw it includes different logic for handling embeds (specifically checking for `/file/`).

I am submitting this Pull Request based on the current `main` branch because my solution directly addresses the issue of embedding non-embeddable pages by using a pattern check *before* attempting to embed. It works well for my needs right now.

I understand that you may have a more comprehensive solution for this problem already in your development branch, or you may choose to integrate this fix differently within your ongoing work. Feel free to close this PR if it's superseded by your existing plans. My goal was simply to contribute a tested fix for the current public version and highlight this issue.

Hope you find this helpful!

Best,

Pontus