### PR TITLE
feat: graceful fallback for private Figma file embeds

### DIFF
--- a/docs/plans/2026-03-07-private-file-fallback-design.md
+++ b/docs/plans/2026-03-07-private-file-fallback-design.md
@@ -1,0 +1,43 @@
+# Private Figma File Fallback Design
+
+## Problem
+
+When a user pastes a link to a private Figma file, the iframe embed shows a "Log in to Figma" screen. Clicking login opens Obsidian's browser, but auth cookies don't flow back to the iframe. The user is stuck with a broken embed.
+
+## Solution
+
+Graceful fallback: render both the iframe and a fallback card. If the iframe fails to load (private/locked file), hide the iframe and show a styled card with file info and a link to open in the browser.
+
+## How It Works
+
+1. When a Figma link is detected, render both the iframe embed and a fallback card.
+2. The fallback card is initially hidden behind/beneath the iframe.
+3. Listen for Figma's `postMessage` events on the iframe.
+4. If the iframe loads successfully -> keep iframe visible, fallback stays hidden.
+5. If the iframe emits a `LOGIN_SCREEN_SHOWN` event -> hide iframe, show fallback card.
+6. Safety net: if no message is received within ~5 seconds, show the fallback card as well.
+
+## Fallback Card Content
+
+- Figma logo (inline SVG)
+- File name (parsed from URL path, e.g. "My-Design-File")
+- File type label (derived from URL pattern: "Design File", "Prototype", "Board", etc.)
+- Message: "This file is private. Open it in your browser to view."
+- "Open in Figma" button that opens the original URL in the default browser
+
+## Styling
+
+- Uses Obsidian CSS variables (`--background-secondary`, `--text-normal`, `--text-muted`, `--interactive-accent`, `--border-color`, etc.)
+- Card has a subtle border, rounded corners, centered layout
+- Works in light mode, dark mode, and custom themes
+
+## File Changes
+
+- `src/main.ts` — add fallback logic to `figmaEmbedProcessor`, add message event listener, add helper to parse file info from URL
+- `styles.css` — add styles for the fallback card using CSS variables
+
+## Constraints
+
+- No new dependencies
+- No settings page
+- No API tokens required

--- a/docs/plans/2026-03-07-private-file-fallback.md
+++ b/docs/plans/2026-03-07-private-file-fallback.md
@@ -1,0 +1,382 @@
+# Private Figma File Fallback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** When a private Figma file embed fails to load, gracefully show a styled fallback card instead of a broken login screen.
+
+**Architecture:** Wrap each embed in a container with both an iframe and a hidden fallback card. Listen for Figma's `postMessage` events — if the iframe loads, hide the fallback; if a login screen is detected or no response arrives within 5 seconds, hide the iframe and show the fallback card.
+
+**Tech Stack:** TypeScript (Obsidian Plugin API), CSS with Obsidian CSS variables
+
+---
+
+### Task 1: Add URL parsing helpers to main.ts
+
+**Files:**
+- Modify: `src/main.ts`
+
+**Step 1: Add helper methods to the FigmaEmbedPlugin class**
+
+Add these two methods before the `onunload()` method in `src/main.ts`:
+
+```typescript
+/**
+ * Parse a human-readable file name from a Figma URL.
+ * E.g. "https://www.figma.com/design/abc123/My-Cool-Design?..." -> "My Cool Design"
+ */
+parseFigmaFileName(url: string): string {
+    try {
+        const pathname = new URL(url).pathname;
+        const segments = pathname.split("/").filter(Boolean);
+        if (segments.length >= 3) {
+            return decodeURIComponent(segments[2]).replace(/-/g, " ");
+        }
+        return "Figma File";
+    } catch {
+        return "Figma File";
+    }
+}
+
+/**
+ * Parse the file type from a Figma URL path segment.
+ * E.g. "/design/..." -> "Design File", "/proto/..." -> "Prototype"
+ */
+parseFigmaFileType(url: string): string {
+    const typeMap: Record<string, string> = {
+        file: "Design File",
+        design: "Design File",
+        proto: "Prototype",
+        board: "FigJam Board",
+        slides: "Slides",
+        deck: "Slide Deck",
+        buzz: "Buzz",
+        site: "Figma Site",
+    };
+    try {
+        const pathname = new URL(url).pathname;
+        const segments = pathname.split("/").filter(Boolean);
+        if (segments.length >= 1) {
+            return typeMap[segments[0]] || "Figma File";
+        }
+        return "Figma File";
+    } catch {
+        return "Figma File";
+    }
+}
+```
+
+**Step 2: Verify build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "feat: add URL parsing helpers for file name and type"
+```
+
+---
+
+### Task 2: Add fallback card CSS to styles.css
+
+**Files:**
+- Modify: `styles.css`
+
+**Step 1: Add fallback card styles**
+
+Append the following to `styles.css`:
+
+```css
+.figmaembed-container {
+    position: relative;
+    width: 100%;
+}
+
+.figmaembed-container .figmaembed-iframe {
+    width: 100%;
+    height: 450px;
+    border: none;
+}
+
+.figmaembed-fallback {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 40px 20px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    background-color: var(--background-secondary);
+    text-align: center;
+}
+
+.figmaembed-fallback.is-visible {
+    display: flex;
+}
+
+.figmaembed-fallback-icon svg {
+    width: 40px;
+    height: 40px;
+}
+
+.figmaembed-fallback-filename {
+    font-size: var(--font-ui-medium);
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.figmaembed-fallback-filetype {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    margin-top: -8px;
+}
+
+.figmaembed-fallback-message {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    max-width: 300px;
+}
+
+.figmaembed-fallback-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+    font-size: var(--font-ui-small);
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: none;
+    border: none;
+}
+
+.figmaembed-fallback-button:hover {
+    background-color: var(--interactive-accent-hover);
+    text-decoration: none;
+    color: var(--text-on-accent);
+}
+```
+
+**Step 2: Verify build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+**Step 3: Commit**
+
+```bash
+git add styles.css
+git commit -m "style: add fallback card styles using Obsidian CSS variables"
+```
+
+---
+
+### Task 3: Refactor figmaEmbedProcessor to render container with iframe + fallback
+
+**Files:**
+- Modify: `src/main.ts`
+
+This is the main change. Replace the current iframe creation logic inside the `if (isEmbeddableUrl)` block with a container that holds both the iframe and the fallback card. All dynamic text uses `textContent` (safe DOM methods, no innerHTML).
+
+**Step 1: Add class property for cleanup tracking**
+
+Add at the top of `FigmaEmbedPlugin` class (after `export default class FigmaEmbedPlugin extends Plugin {`):
+
+```typescript
+private messageHandlers: Array<(event: MessageEvent) => void> = [];
+```
+
+**Step 2: Add a private method to build the fallback card**
+
+Add this method to the class, before `parseFigmaFileName`:
+
+```typescript
+private createFallbackCard(fileName: string, fileType: string, figmaUrl: string): HTMLElement {
+    const fallback = document.createElement("div");
+    fallback.classList.add("figmaembed-fallback");
+
+    // Figma logo (static SVG, no user content)
+    const iconDiv = document.createElement("div");
+    iconDiv.classList.add("figmaembed-fallback-icon");
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("viewBox", "0 0 38 57");
+    svg.setAttribute("fill", "none");
+    const paths = [
+        { d: "M19 28.5C19 23.2533 23.2533 19 28.5 19C33.7467 19 38 23.2533 38 28.5C38 33.7467 33.7467 38 28.5 38C23.2533 38 19 33.7467 19 28.5Z", fill: "#1ABCFE" },
+        { d: "M0 47.5C0 42.2533 4.25329 38 9.5 38H19V47.5C19 52.7467 14.7467 57 9.5 57C4.25329 57 0 52.7467 0 47.5Z", fill: "#0ACF83" },
+        { d: "M19 0V19H28.5C33.7467 19 38 14.7467 38 9.5C38 4.25329 33.7467 0 28.5 0H19Z", fill: "#FF7262" },
+        { d: "M0 9.5C0 14.7467 4.25329 19 9.5 19H19V0H9.5C4.25329 0 0 4.25329 0 9.5Z", fill: "#F24E1E" },
+        { d: "M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z", fill: "#A259FF" },
+    ];
+    for (const p of paths) {
+        const path = document.createElementNS(svgNS, "path");
+        path.setAttribute("d", p.d);
+        path.setAttribute("fill", p.fill);
+        svg.appendChild(path);
+    }
+    iconDiv.appendChild(svg);
+    fallback.appendChild(iconDiv);
+
+    // File name (textContent — safe from XSS)
+    const nameDiv = document.createElement("div");
+    nameDiv.classList.add("figmaembed-fallback-filename");
+    nameDiv.textContent = fileName;
+    fallback.appendChild(nameDiv);
+
+    // File type
+    const typeDiv = document.createElement("div");
+    typeDiv.classList.add("figmaembed-fallback-filetype");
+    typeDiv.textContent = fileType;
+    fallback.appendChild(typeDiv);
+
+    // Message
+    const msgDiv = document.createElement("div");
+    msgDiv.classList.add("figmaembed-fallback-message");
+    msgDiv.textContent = "This file is private. Open it in your browser to view.";
+    fallback.appendChild(msgDiv);
+
+    // Open button
+    const btn = document.createElement("a");
+    btn.classList.add("figmaembed-fallback-button");
+    btn.href = figmaUrl;
+    btn.target = "_blank";
+    btn.rel = "noopener noreferrer";
+    btn.textContent = "Open in Figma";
+    fallback.appendChild(btn);
+
+    return fallback;
+}
+```
+
+**Step 3: Replace the iframe creation block in figmaEmbedProcessor**
+
+Replace the entire `if (isEmbeddableUrl) { ... }` block (lines 51-69) with:
+
+```typescript
+if (isEmbeddableUrl) {
+    const fileName = this.parseFigmaFileName(figmaUrl);
+    const fileType = this.parseFigmaFileType(figmaUrl);
+
+    // Create container
+    const container = document.createElement("div");
+    container.classList.add("figmaembed-container");
+
+    // Create iframe
+    const iframe = document.createElement("iframe");
+    iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(
+        figmaUrl
+    )}`;
+    iframe.classList.add("figmaembed-iframe");
+    iframe.setAttribute("allowfullscreen", "true");
+
+    // Create fallback card (uses safe DOM methods, no innerHTML)
+    const fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
+
+    container.appendChild(iframe);
+    container.appendChild(fallback);
+
+    // Replace the original link with the container
+    link.parentNode?.replaceChild(container, link);
+
+    // Listen for postMessage from Figma embed
+    const messageHandler = (event: MessageEvent) => {
+        if (event.origin !== "https://www.figma.com") return;
+
+        let data = event.data;
+        if (typeof data === "string") {
+            try { data = JSON.parse(data); } catch { return; }
+        }
+
+        if (data?.type === "EMBED_LOADED" || data?.type === "INITIAL_LOAD_COMPLETE") {
+            clearTimeout(fallbackTimeout);
+            iframe.style.display = "";
+            fallback.classList.remove("is-visible");
+            window.removeEventListener("message", messageHandler);
+        } else if (data?.type === "LOGIN_SCREEN_SHOWN") {
+            clearTimeout(fallbackTimeout);
+            iframe.style.display = "none";
+            fallback.classList.add("is-visible");
+            window.removeEventListener("message", messageHandler);
+        }
+    };
+
+    window.addEventListener("message", messageHandler);
+    this.messageHandlers.push(messageHandler);
+
+    // Safety net: if no message in 5s, show fallback
+    const fallbackTimeout = setTimeout(() => {
+        if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
+            iframe.style.display = "none";
+            fallback.classList.add("is-visible");
+            window.removeEventListener("message", messageHandler);
+        }
+    }, 5000);
+}
+```
+
+**Step 4: Update onunload for cleanup**
+
+Replace the `onunload` method with:
+
+```typescript
+async onunload() {
+    this.messageHandlers.forEach(handler => {
+        window.removeEventListener("message", handler);
+    });
+    this.messageHandlers = [];
+}
+```
+
+**Step 5: Verify build compiles**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors.
+
+**Step 6: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "feat: add fallback card for private Figma file embeds"
+```
+
+---
+
+### Task 4: Manual testing
+
+**Step 1: Test with a public Figma file**
+
+1. Run `npm run dev` to start dev build
+2. Copy the built `main.js` and `styles.css` to your Obsidian vault's `.obsidian/plugins/figma-embed/` folder
+3. Paste a public Figma link in a note
+4. Switch to Reading mode
+5. Expected: iframe loads normally, no fallback card visible
+
+**Step 2: Test with a private Figma file**
+
+1. Paste a private Figma link in a note
+2. Switch to Reading mode
+3. Expected: after ~5 seconds (or immediately if LOGIN_SCREEN_SHOWN fires), the iframe is hidden and the fallback card appears with:
+   - Figma logo
+   - File name parsed from URL
+   - File type (Design File, Prototype, etc.)
+   - "This file is private. Open it in your browser to view."
+   - "Open in Figma" button that opens the URL
+
+**Step 3: Test theme compatibility**
+
+1. Switch between light and dark mode
+2. If you have a custom theme, test with that too
+3. Expected: fallback card adapts colors correctly
+
+**Step 4: Commit any fixes if needed**
+
+```bash
+git add -A
+git commit -m "chore: testing fixes"
+```

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,15 +55,14 @@ export default class FigmaEmbedPlugin extends Plugin {
 
         const { name: fileName, type: fileType } = this.parseFigmaFileInfo(figmaUrl);
 
-        const container = document.createElement("div");
-        container.classList.add("figmaembed-container");
-
-        const iframe = document.createElement("iframe");
-        iframe.src = `${FIGMA_ORIGIN}/embed?embed_host=obsidian&url=${encodeURIComponent(figmaUrl)}`;
-        iframe.classList.add("figmaembed-iframe");
-        iframe.setAttribute("allowfullscreen", "true");
-
-        container.appendChild(iframe);
+        const container = createDiv({ cls: "figmaembed-container" });
+        const iframe = container.createEl("iframe", {
+            cls: "figmaembed-iframe",
+            attr: {
+                src: `${FIGMA_ORIGIN}/embed?embed_host=obsidian&url=${encodeURIComponent(figmaUrl)}`,
+                allowfullscreen: "true",
+            },
+        });
 
         const parent = link.parentNode;
         if (!parent) return;
@@ -132,53 +131,31 @@ export default class FigmaEmbedPlugin extends Plugin {
     }
 
     private createFallbackCard(fileName: string, fileType: string, figmaUrl: string): HTMLElement {
-        const fallback = document.createElement("div");
-        fallback.classList.add("figmaembed-fallback");
+        const fallback = createDiv({ cls: "figmaembed-fallback" });
 
         // Figma logo (static SVG, no user content)
-        const iconDiv = document.createElement("div");
-        iconDiv.classList.add("figmaembed-fallback-icon");
-        const svgNS = "http://www.w3.org/2000/svg";
-        const svg = document.createElementNS(svgNS, "svg");
-        svg.setAttribute("viewBox", "0 0 38 57");
-        svg.setAttribute("fill", "none");
+        const iconDiv = fallback.createDiv({ cls: "figmaembed-fallback-icon" });
+        const svg = iconDiv.createSvg("svg", { attr: { viewBox: "0 0 38 57", fill: "none" } });
         for (const p of FIGMA_LOGO_PATHS) {
-            const path = document.createElementNS(svgNS, "path");
-            path.setAttribute("d", p.d);
-            path.setAttribute("fill", p.fill);
-            svg.appendChild(path);
+            svg.createSvg("path", { attr: { d: p.d, fill: p.fill } });
         }
-        iconDiv.appendChild(svg);
 
-        const header = document.createElement("div");
-        header.classList.add("figmaembed-fallback-header");
+        const header = fallback.createDiv({ cls: "figmaembed-fallback-header" });
         header.appendChild(iconDiv);
+        // File name (text — safe from XSS via Obsidian's createDiv)
+        header.createDiv({ cls: "figmaembed-fallback-filename", text: fileName });
+        header.createSpan({ cls: "figmaembed-fallback-filetype", text: fileType });
 
-        // File name (textContent — safe from XSS)
-        const nameDiv = document.createElement("div");
-        nameDiv.classList.add("figmaembed-fallback-filename");
-        nameDiv.textContent = fileName;
-        header.appendChild(nameDiv);
-
-        const typeDiv = document.createElement("span");
-        typeDiv.classList.add("figmaembed-fallback-filetype");
-        typeDiv.textContent = fileType;
-        header.appendChild(typeDiv);
-
-        fallback.appendChild(header);
-
-        const msgDiv = document.createElement("div");
-        msgDiv.classList.add("figmaembed-fallback-message");
-        msgDiv.textContent = "Unable to load this embed. The file may be private, or the connection timed out.";
-        fallback.appendChild(msgDiv);
-
-        const btn = document.createElement("a");
-        btn.classList.add("figmaembed-fallback-button");
-        btn.href = figmaUrl;
-        btn.target = "_blank";
-        btn.rel = "noopener noreferrer";
-        btn.textContent = "Open in Figma";
-        fallback.appendChild(btn);
+        fallback.createDiv({
+            cls: "figmaembed-fallback-message",
+            text: "Unable to load this embed. The file may be private, or the connection timed out.",
+        });
+        fallback.createEl("a", {
+            cls: "figmaembed-fallback-button",
+            text: "Open in Figma",
+            href: figmaUrl,
+            attr: { target: "_blank", rel: "noopener noreferrer" },
+        });
 
         return fallback;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
 
 export default class FigmaEmbedPlugin extends Plugin {
+    private messageHandlers: Array<(event: MessageEvent) => void> = [];
+
     async onload() {
         // This part stays the same - it registers the post processor
         this.registerMarkdownPostProcessor(this.figmaEmbedProcessor.bind(this));
@@ -49,24 +51,63 @@ export default class FigmaEmbedPlugin extends Plugin {
 
             // If the URL matches a pattern that suggests it's embeddable based on its structure
             if (isEmbeddableUrl) {
-                // Create the iframe using the hardcoded embed URL structure.
-                // This happens unconditionally for matching links.
+                const fileName = this.parseFigmaFileName(figmaUrl);
+                const fileType = this.parseFigmaFileType(figmaUrl);
+
+                // Create container
+                const container = document.createElement("div");
+                container.classList.add("figmaembed-container");
+
+                // Create iframe
                 const iframe = document.createElement("iframe");
                 iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(
                     figmaUrl
                 )}`;
-
-                // Add class and styles for the iframe
                 iframe.classList.add("figmaembed-iframe");
-                iframe.style.width = "100%";
-                iframe.style.height = "450px"; // Adjust as needed
-                iframe.style.border = "none";
                 iframe.setAttribute("allowfullscreen", "true");
 
-                // Replace the original link with the iframe
-                link.parentNode?.replaceChild(iframe, link);
+                // Create fallback card (uses safe DOM methods, no innerHTML)
+                const fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
 
-                // console.log(`Attempting embed for pattern match: ${figmaUrl}`); // Optional log
+                container.appendChild(iframe);
+                container.appendChild(fallback);
+
+                // Replace the original link with the container
+                link.parentNode?.replaceChild(container, link);
+
+                // Listen for postMessage from Figma embed
+                const messageHandler = (event: MessageEvent) => {
+                    if (event.origin !== "https://www.figma.com") return;
+
+                    let data = event.data;
+                    if (typeof data === "string") {
+                        try { data = JSON.parse(data); } catch { return; }
+                    }
+
+                    if (data?.type === "EMBED_LOADED" || data?.type === "INITIAL_LOAD_COMPLETE") {
+                        clearTimeout(fallbackTimeout);
+                        iframe.style.display = "";
+                        fallback.classList.remove("is-visible");
+                        window.removeEventListener("message", messageHandler);
+                    } else if (data?.type === "LOGIN_SCREEN_SHOWN") {
+                        clearTimeout(fallbackTimeout);
+                        iframe.style.display = "none";
+                        fallback.classList.add("is-visible");
+                        window.removeEventListener("message", messageHandler);
+                    }
+                };
+
+                window.addEventListener("message", messageHandler);
+                this.messageHandlers.push(messageHandler);
+
+                // Safety net: if no message in 5s, show fallback
+                const fallbackTimeout = setTimeout(() => {
+                    if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
+                        iframe.style.display = "none";
+                        fallback.classList.add("is-visible");
+                        window.removeEventListener("message", messageHandler);
+                    }
+                }, 5000);
             } else {
                 // If the URL does NOT match the STRICTER pattern, do nothing.
                 // It remains a standard text link instantly.
@@ -75,6 +116,63 @@ export default class FigmaEmbedPlugin extends Plugin {
             }
         });
     } // <- END of figmaEmbedProcessor content
+
+    private createFallbackCard(fileName: string, fileType: string, figmaUrl: string): HTMLElement {
+        const fallback = document.createElement("div");
+        fallback.classList.add("figmaembed-fallback");
+
+        // Figma logo (static SVG, no user content)
+        const iconDiv = document.createElement("div");
+        iconDiv.classList.add("figmaembed-fallback-icon");
+        const svgNS = "http://www.w3.org/2000/svg";
+        const svg = document.createElementNS(svgNS, "svg");
+        svg.setAttribute("viewBox", "0 0 38 57");
+        svg.setAttribute("fill", "none");
+        const paths = [
+            { d: "M19 28.5C19 23.2533 23.2533 19 28.5 19C33.7467 19 38 23.2533 38 28.5C38 33.7467 33.7467 38 28.5 38C23.2533 38 19 33.7467 19 28.5Z", fill: "#1ABCFE" },
+            { d: "M0 47.5C0 42.2533 4.25329 38 9.5 38H19V47.5C19 52.7467 14.7467 57 9.5 57C4.25329 57 0 52.7467 0 47.5Z", fill: "#0ACF83" },
+            { d: "M19 0V19H28.5C33.7467 19 38 14.7467 38 9.5C38 4.25329 33.7467 0 28.5 0H19Z", fill: "#FF7262" },
+            { d: "M0 9.5C0 14.7467 4.25329 19 9.5 19H19V0H9.5C4.25329 0 0 4.25329 0 9.5Z", fill: "#F24E1E" },
+            { d: "M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z", fill: "#A259FF" },
+        ];
+        for (const p of paths) {
+            const path = document.createElementNS(svgNS, "path");
+            path.setAttribute("d", p.d);
+            path.setAttribute("fill", p.fill);
+            svg.appendChild(path);
+        }
+        iconDiv.appendChild(svg);
+        fallback.appendChild(iconDiv);
+
+        // File name (textContent — safe from XSS)
+        const nameDiv = document.createElement("div");
+        nameDiv.classList.add("figmaembed-fallback-filename");
+        nameDiv.textContent = fileName;
+        fallback.appendChild(nameDiv);
+
+        // File type
+        const typeDiv = document.createElement("div");
+        typeDiv.classList.add("figmaembed-fallback-filetype");
+        typeDiv.textContent = fileType;
+        fallback.appendChild(typeDiv);
+
+        // Message
+        const msgDiv = document.createElement("div");
+        msgDiv.classList.add("figmaembed-fallback-message");
+        msgDiv.textContent = "This file is private. Open it in your browser to view.";
+        fallback.appendChild(msgDiv);
+
+        // Open button
+        const btn = document.createElement("a");
+        btn.classList.add("figmaembed-fallback-button");
+        btn.href = figmaUrl;
+        btn.target = "_blank";
+        btn.rel = "noopener noreferrer";
+        btn.textContent = "Open in Figma";
+        fallback.appendChild(btn);
+
+        return fallback;
+    }
 
     /**
      * Parse a human-readable file name from a Figma URL.
@@ -120,8 +218,10 @@ export default class FigmaEmbedPlugin extends Plugin {
         }
     }
 
-    // This part stays the same
     async onunload() {
-        // Clean up logic if needed
+        this.messageHandlers.forEach(handler => {
+            window.removeEventListener("message", handler);
+        });
+        this.messageHandlers = [];
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,50 @@ export default class FigmaEmbedPlugin extends Plugin {
         });
     } // <- END of figmaEmbedProcessor content
 
+    /**
+     * Parse a human-readable file name from a Figma URL.
+     * E.g. "https://www.figma.com/design/abc123/My-Cool-Design?..." -> "My Cool Design"
+     */
+    parseFigmaFileName(url: string): string {
+        try {
+            const pathname = new URL(url).pathname;
+            const segments = pathname.split("/").filter(Boolean);
+            if (segments.length >= 3) {
+                return decodeURIComponent(segments[2]).replace(/-/g, " ");
+            }
+            return "Figma File";
+        } catch {
+            return "Figma File";
+        }
+    }
+
+    /**
+     * Parse the file type from a Figma URL path segment.
+     * E.g. "/design/..." -> "Design File", "/proto/..." -> "Prototype"
+     */
+    parseFigmaFileType(url: string): string {
+        const typeMap: Record<string, string> = {
+            file: "Design File",
+            design: "Design File",
+            proto: "Prototype",
+            board: "FigJam Board",
+            slides: "Slides",
+            deck: "Slide Deck",
+            buzz: "Buzz",
+            site: "Figma Site",
+        };
+        try {
+            const pathname = new URL(url).pathname;
+            const segments = pathname.split("/").filter(Boolean);
+            if (segments.length >= 1) {
+                return typeMap[segments[0]] || "Figma File";
+            }
+            return "Figma File";
+        } catch {
+            return "Figma File";
+        }
+    }
+
     // This part stays the same
     async onunload() {
         // Clean up logic if needed

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
 
+const FIGMA_ORIGIN = "https://www.figma.com";
 const FALLBACK_TIMEOUT_MS = 15000;
 
 const FIGMA_LOGO_PATHS = [
@@ -10,16 +11,7 @@ const FIGMA_LOGO_PATHS = [
     { d: "M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z", fill: "#A259FF" },
 ];
 
-const EMBEDDABLE_PATTERNS = [
-    /\/file\/[^\/]+/,
-    /\/design\/[^\/]+/,
-    /\/proto\/[^\/]+/,
-    /\/board\/[^\/]+/,
-    /\/slides\/[^\/]+/,
-    /\/deck\/[^\/]+/,
-    /\/buzz\/[^\/]+/,
-    /\/site\/[^\/]+/,
-];
+const EMBEDDABLE_PATTERN = /\/(file|design|proto|board|slides|deck|buzz|site)\/[^\/]+/;
 
 const FILE_TYPE_MAP: Record<string, string> = {
     file: "Design File",
@@ -45,7 +37,7 @@ export default class FigmaEmbedPlugin extends Plugin {
      */
     figmaEmbedProcessor(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
         const figmaLinks = el.querySelectorAll(
-            'a[href^="https://www.figma.com/"]'
+            `a[href^="${FIGMA_ORIGIN}/"]`
         );
 
         figmaLinks.forEach((link: HTMLAnchorElement) => {
@@ -59,9 +51,7 @@ export default class FigmaEmbedPlugin extends Plugin {
 
     private processLink(link: HTMLAnchorElement) {
         const figmaUrl = link.href;
-        const isEmbeddableUrl = EMBEDDABLE_PATTERNS.some(pattern => pattern.test(figmaUrl));
-
-        if (!isEmbeddableUrl) return;
+        if (!EMBEDDABLE_PATTERN.test(figmaUrl)) return;
 
         const { name: fileName, type: fileType } = this.parseFigmaFileInfo(figmaUrl);
 
@@ -69,46 +59,55 @@ export default class FigmaEmbedPlugin extends Plugin {
         container.classList.add("figmaembed-container");
 
         const iframe = document.createElement("iframe");
-        iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(figmaUrl)}`;
+        iframe.src = `${FIGMA_ORIGIN}/embed?embed_host=obsidian&url=${encodeURIComponent(figmaUrl)}`;
         iframe.classList.add("figmaembed-iframe");
         iframe.setAttribute("allowfullscreen", "true");
 
-        // Create fallback card (uses safe DOM methods, no innerHTML)
-        const fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
-
         container.appendChild(iframe);
-        container.appendChild(fallback);
 
         const parent = link.parentNode;
         if (!parent) return;
         parent.replaceChild(container, link);
 
-        const showFallback = (timeout: ReturnType<typeof setTimeout>) => {
-            clearTimeout(timeout);
-            iframe.style.display = "none";
-            fallback.classList.add("is-visible");
+        // Lazily create fallback card only when needed
+        let fallback: HTMLElement | null = null;
+        const ensureFallback = () => {
+            if (!fallback) {
+                fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
+                container.appendChild(fallback);
+            }
+            return fallback;
+        };
+
+        const cleanup = () => {
+            clearInterval(cleanupInterval);
+            clearTimeout(fallbackTimeout);
             window.removeEventListener("message", messageHandler);
         };
 
-        const showEmbed = (timeout: ReturnType<typeof setTimeout>) => {
-            clearTimeout(timeout);
-            iframe.style.display = "";
-            fallback.classList.remove("is-visible");
-            window.removeEventListener("message", messageHandler);
+        const resolve = (showEmbed: boolean) => {
+            cleanup();
+            if (showEmbed) {
+                iframe.style.display = "";
+                if (fallback) fallback.classList.remove("is-visible");
+            } else {
+                iframe.style.display = "none";
+                ensureFallback().classList.add("is-visible");
+            }
         };
 
         // Figma sends plain strings (e.g. "INITIAL_LOAD") or JSON objects with a .type field
         const messageHandler = (event: MessageEvent) => {
-            if (event.origin !== "https://www.figma.com") return;
+            if (event.origin !== FIGMA_ORIGIN) return;
             if (event.source !== iframe.contentWindow) return;
 
             const data = event.data;
             const eventType = typeof data === "string" ? data : data?.type;
 
             if (eventType === "INITIAL_LOAD" || eventType === "EMBED_LOADED") {
-                showEmbed(fallbackTimeout);
+                resolve(true);
             } else if (eventType === "LOGIN_SCREEN_SHOWN") {
-                showFallback(fallbackTimeout);
+                resolve(false);
             }
         };
 
@@ -117,27 +116,19 @@ export default class FigmaEmbedPlugin extends Plugin {
         // Safety net: if Figma doesn't respond (network error, outage, etc.), show fallback.
         // Keep the listener active so a late-loading embed can still recover.
         const fallbackTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
-            if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
+            if (iframe.style.display !== "none") {
                 iframe.style.display = "none";
-                fallback.classList.add("is-visible");
+                ensureFallback().classList.add("is-visible");
             }
         }, FALLBACK_TIMEOUT_MS);
 
         // Self-cleanup: remove handler when iframe leaves the DOM (e.g. note navigation)
         const cleanupInterval = setInterval(() => {
-            if (!iframe.isConnected) {
-                clearInterval(cleanupInterval);
-                clearTimeout(fallbackTimeout);
-                window.removeEventListener("message", messageHandler);
-            }
+            if (!iframe.isConnected) cleanup();
         }, 2000);
 
         // Also clean up on plugin unload
-        this.register(() => {
-            clearInterval(cleanupInterval);
-            clearTimeout(fallbackTimeout);
-            window.removeEventListener("message", messageHandler);
-        });
+        this.register(cleanup);
     }
 
     private createFallbackCard(fileName: string, fileType: string, figmaUrl: string): HTMLElement {

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,17 +81,17 @@ export default class FigmaEmbedPlugin extends Plugin {
                     if (event.origin !== "https://www.figma.com") return;
                     if (event.source !== iframe.contentWindow) return;
 
-                    let data = event.data;
-                    if (typeof data === "string") {
-                        try { data = JSON.parse(data); } catch { return; }
-                    }
+                    const data = event.data;
 
-                    if (data?.type === "EMBED_LOADED" || data?.type === "INITIAL_LOAD_COMPLETE") {
+                    // Figma sends plain strings (e.g. "INITIAL_LOAD") or JSON objects
+                    const eventType = typeof data === "string" ? data : data?.type;
+
+                    if (eventType === "INITIAL_LOAD" || eventType === "EMBED_LOADED") {
                         clearTimeout(fallbackTimeout);
                         iframe.style.display = "";
                         fallback.classList.remove("is-visible");
                         window.removeEventListener("message", messageHandler);
-                    } else if (data?.type === "LOGIN_SCREEN_SHOWN") {
+                    } else if (eventType === "LOGIN_SCREEN_SHOWN") {
                         clearTimeout(fallbackTimeout);
                         iframe.style.display = "none";
                         fallback.classList.add("is-visible");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Plugin, MarkdownPostProcessorContext } from "obsidian";
 
 export default class FigmaEmbedPlugin extends Plugin {
     private messageHandlers: Array<(event: MessageEvent) => void> = [];
+    private fallbackTimeouts: ReturnType<typeof setTimeout>[] = [];
 
     async onload() {
         // This part stays the same - it registers the post processor
@@ -78,6 +79,7 @@ export default class FigmaEmbedPlugin extends Plugin {
                 // Listen for postMessage from Figma embed
                 const messageHandler = (event: MessageEvent) => {
                     if (event.origin !== "https://www.figma.com") return;
+                    if (event.source !== iframe.contentWindow) return;
 
                     let data = event.data;
                     if (typeof data === "string") {
@@ -101,13 +103,14 @@ export default class FigmaEmbedPlugin extends Plugin {
                 this.messageHandlers.push(messageHandler);
 
                 // Safety net: if no message in 5s, show fallback
-                const fallbackTimeout = setTimeout(() => {
+                const fallbackTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
                     if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
                         iframe.style.display = "none";
                         fallback.classList.add("is-visible");
                         window.removeEventListener("message", messageHandler);
                     }
                 }, 5000);
+                this.fallbackTimeouts.push(fallbackTimeout);
             } else {
                 // If the URL does NOT match the STRICTER pattern, do nothing.
                 // It remains a standard text link instantly.
@@ -218,10 +221,12 @@ export default class FigmaEmbedPlugin extends Plugin {
         }
     }
 
-    async onunload() {
+    onunload() {
         this.messageHandlers.forEach(handler => {
             window.removeEventListener("message", handler);
         });
         this.messageHandlers = [];
+        this.fallbackTimeouts.forEach(id => clearTimeout(id));
+        this.fallbackTimeouts = [];
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,124 +1,144 @@
 import { Plugin, MarkdownPostProcessorContext } from "obsidian";
 
-export default class FigmaEmbedPlugin extends Plugin {
-    private messageHandlers: Array<(event: MessageEvent) => void> = [];
-    private fallbackTimeouts: ReturnType<typeof setTimeout>[] = [];
+const FALLBACK_TIMEOUT_MS = 15000;
 
-    async onload() {
-        // This part stays the same - it registers the post processor
+const FIGMA_LOGO_PATHS = [
+    { d: "M19 28.5C19 23.2533 23.2533 19 28.5 19C33.7467 19 38 23.2533 38 28.5C38 33.7467 33.7467 38 28.5 38C23.2533 38 19 33.7467 19 28.5Z", fill: "#1ABCFE" },
+    { d: "M0 47.5C0 42.2533 4.25329 38 9.5 38H19V47.5C19 52.7467 14.7467 57 9.5 57C4.25329 57 0 52.7467 0 47.5Z", fill: "#0ACF83" },
+    { d: "M19 0V19H28.5C33.7467 19 38 14.7467 38 9.5C38 4.25329 33.7467 0 28.5 0H19Z", fill: "#FF7262" },
+    { d: "M0 9.5C0 14.7467 4.25329 19 9.5 19H19V0H9.5C4.25329 0 0 4.25329 0 9.5Z", fill: "#F24E1E" },
+    { d: "M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z", fill: "#A259FF" },
+];
+
+const EMBEDDABLE_PATTERNS = [
+    /\/file\/[^\/]+/,
+    /\/design\/[^\/]+/,
+    /\/proto\/[^\/]+/,
+    /\/board\/[^\/]+/,
+    /\/slides\/[^\/]+/,
+    /\/deck\/[^\/]+/,
+    /\/buzz\/[^\/]+/,
+    /\/site\/[^\/]+/,
+];
+
+const FILE_TYPE_MAP: Record<string, string> = {
+    file: "Design File",
+    design: "Design File",
+    proto: "Prototype",
+    board: "FigJam Board",
+    slides: "Slides",
+    deck: "Slide Deck",
+    buzz: "Buzz",
+    site: "Figma Site",
+};
+
+export default class FigmaEmbedPlugin extends Plugin {
+    onload() {
         this.registerMarkdownPostProcessor(this.figmaEmbedProcessor.bind(this));
     }
 
     /**
-     * Markdown post processor function to find Figma links and potentially embed them based on URL patterns.
-     * This version relies ONLY on pattern matching. If a URL matches a pattern, it attempts to embed.
-     * URLs not matching patterns (or matching patterns but failing to load) will remain as links.
-     *
-     * @param el - The HTML element being processed.
-     * @param ctx - The context of the markdown processing.
+     * Finds Figma links and replaces them with embedded iframes.
+     * URLs matching embeddable patterns get an iframe + fallback card.
+     * If the embed fails (private file, network error, timeout), a styled
+     * fallback card is shown instead.
      */
     figmaEmbedProcessor(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
-        // Select all <a> tags with an href starting with the Figma domain
         const figmaLinks = el.querySelectorAll(
             'a[href^="https://www.figma.com/"]'
         );
 
-        // --- UPDATED Pattern Definition (Pattern-Only Approach) ---
-        // Define URL patterns that indicate an item *likely* to be embeddable asset
-        // by requiring at least one character *after* the main path segment slash (e.g., /file/abc).
-        // If a URL matches one of these patterns, the plugin will attempt to embed it.
-        // If a URL does NOT match these patterns, it will remain a standard text link.
-        // NOTE: This approach does NOT use the oEmbed endpoint, so it cannot
-        // reliably check if a matching link is actually embeddable (e.g., due to permissions,
-        // or if the pattern matches a page that isn't truly an embeddable asset).
-        // Matching links that aren't embeddable will result in a broken iframe.
-        const embeddablePatterns = [
-            /\/file\/[^\/]+/,   // Matches /file/ followed by one or more non-slash characters
-            /\/design\/[^\/]+/, // Matches /design/ followed by one or more non-slash characters
-            /\/proto\/[^\/]+/,  // Matches /proto/ followed by one or more non-slash characters
-            /\/board\/[^\/]+/,  // Matches /board/ followed by one or more non-slash characters
-            /\/slides\/[^\/]+/, // Matches /slides/ followed by one or more non-slash characters
-            /\/deck\/[^\/]+/,    // Matches /deck/ followed by one or more non-slash characters
-            /\/buzz\/[^\/]+/,   // Matches /buzz/ followed by one or more non-slash characters
-            /\/site\/[^\/]+/    // Matches /site/ followed by one or more non-slash characters
-        ];
-
-        // Iterate over each found Figma link
         figmaLinks.forEach((link: HTMLAnchorElement) => {
-            const figmaUrl = link.href; // Get the original URL from the link in the markdown
-
-            // Check if the original URL matches any of the defined STRICTER embeddable patterns
-            const isEmbeddableUrl = embeddablePatterns.some(pattern => pattern.test(figmaUrl));
-
-            // If the URL matches a pattern that suggests it's embeddable based on its structure
-            if (isEmbeddableUrl) {
-                const fileName = this.parseFigmaFileName(figmaUrl);
-                const fileType = this.parseFigmaFileType(figmaUrl);
-
-                // Create container
-                const container = document.createElement("div");
-                container.classList.add("figmaembed-container");
-
-                // Create iframe
-                const iframe = document.createElement("iframe");
-                iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(
-                    figmaUrl
-                )}`;
-                iframe.classList.add("figmaembed-iframe");
-                iframe.setAttribute("allowfullscreen", "true");
-
-                // Create fallback card (uses safe DOM methods, no innerHTML)
-                const fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
-
-                container.appendChild(iframe);
-                container.appendChild(fallback);
-
-                // Replace the original link with the container
-                link.parentNode?.replaceChild(container, link);
-
-                // Listen for postMessage from Figma embed
-                const messageHandler = (event: MessageEvent) => {
-                    if (event.origin !== "https://www.figma.com") return;
-                    if (event.source !== iframe.contentWindow) return;
-
-                    const data = event.data;
-
-                    // Figma sends plain strings (e.g. "INITIAL_LOAD") or JSON objects
-                    const eventType = typeof data === "string" ? data : data?.type;
-
-                    if (eventType === "INITIAL_LOAD" || eventType === "EMBED_LOADED") {
-                        clearTimeout(fallbackTimeout);
-                        iframe.style.display = "";
-                        fallback.classList.remove("is-visible");
-                        window.removeEventListener("message", messageHandler);
-                    } else if (eventType === "LOGIN_SCREEN_SHOWN") {
-                        clearTimeout(fallbackTimeout);
-                        iframe.style.display = "none";
-                        fallback.classList.add("is-visible");
-                        window.removeEventListener("message", messageHandler);
-                    }
-                };
-
-                window.addEventListener("message", messageHandler);
-                this.messageHandlers.push(messageHandler);
-
-                // Safety net: if no message in 5s, show fallback
-                const fallbackTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
-                    if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
-                        iframe.style.display = "none";
-                        fallback.classList.add("is-visible");
-                        window.removeEventListener("message", messageHandler);
-                    }
-                }, 5000);
-                this.fallbackTimeouts.push(fallbackTimeout);
-            } else {
-                // If the URL does NOT match the STRICTER pattern, do nothing.
-                // It remains a standard text link instantly.
-                // This covers URLs like https://www.figma.com/buzz/ or https://www.figma.com/pricing/
-                // console.log(`Figma link does not match stricter embeddable patterns, leaving as link: ${figmaUrl}`); // Optional log
+            try {
+                this.processLink(link);
+            } catch (e) {
+                console.error("Failed to process Figma embed:", link.href, e);
             }
         });
-    } // <- END of figmaEmbedProcessor content
+    }
+
+    private processLink(link: HTMLAnchorElement) {
+        const figmaUrl = link.href;
+        const isEmbeddableUrl = EMBEDDABLE_PATTERNS.some(pattern => pattern.test(figmaUrl));
+
+        if (!isEmbeddableUrl) return;
+
+        const { name: fileName, type: fileType } = this.parseFigmaFileInfo(figmaUrl);
+
+        const container = document.createElement("div");
+        container.classList.add("figmaembed-container");
+
+        const iframe = document.createElement("iframe");
+        iframe.src = `https://www.figma.com/embed?embed_host=obsidian&url=${encodeURIComponent(figmaUrl)}`;
+        iframe.classList.add("figmaembed-iframe");
+        iframe.setAttribute("allowfullscreen", "true");
+
+        // Create fallback card (uses safe DOM methods, no innerHTML)
+        const fallback = this.createFallbackCard(fileName, fileType, figmaUrl);
+
+        container.appendChild(iframe);
+        container.appendChild(fallback);
+
+        const parent = link.parentNode;
+        if (!parent) return;
+        parent.replaceChild(container, link);
+
+        const showFallback = (timeout: ReturnType<typeof setTimeout>) => {
+            clearTimeout(timeout);
+            iframe.style.display = "none";
+            fallback.classList.add("is-visible");
+            window.removeEventListener("message", messageHandler);
+        };
+
+        const showEmbed = (timeout: ReturnType<typeof setTimeout>) => {
+            clearTimeout(timeout);
+            iframe.style.display = "";
+            fallback.classList.remove("is-visible");
+            window.removeEventListener("message", messageHandler);
+        };
+
+        // Figma sends plain strings (e.g. "INITIAL_LOAD") or JSON objects with a .type field
+        const messageHandler = (event: MessageEvent) => {
+            if (event.origin !== "https://www.figma.com") return;
+            if (event.source !== iframe.contentWindow) return;
+
+            const data = event.data;
+            const eventType = typeof data === "string" ? data : data?.type;
+
+            if (eventType === "INITIAL_LOAD" || eventType === "EMBED_LOADED") {
+                showEmbed(fallbackTimeout);
+            } else if (eventType === "LOGIN_SCREEN_SHOWN") {
+                showFallback(fallbackTimeout);
+            }
+        };
+
+        window.addEventListener("message", messageHandler);
+
+        // Safety net: if Figma doesn't respond (network error, outage, etc.), show fallback.
+        // Keep the listener active so a late-loading embed can still recover.
+        const fallbackTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+            if (!fallback.classList.contains("is-visible") && iframe.style.display !== "none") {
+                iframe.style.display = "none";
+                fallback.classList.add("is-visible");
+            }
+        }, FALLBACK_TIMEOUT_MS);
+
+        // Self-cleanup: remove handler when iframe leaves the DOM (e.g. note navigation)
+        const cleanupInterval = setInterval(() => {
+            if (!iframe.isConnected) {
+                clearInterval(cleanupInterval);
+                clearTimeout(fallbackTimeout);
+                window.removeEventListener("message", messageHandler);
+            }
+        }, 2000);
+
+        // Also clean up on plugin unload
+        this.register(() => {
+            clearInterval(cleanupInterval);
+            clearTimeout(fallbackTimeout);
+            window.removeEventListener("message", messageHandler);
+        });
+    }
 
     private createFallbackCard(fileName: string, fileType: string, figmaUrl: string): HTMLElement {
         const fallback = document.createElement("div");
@@ -131,14 +151,7 @@ export default class FigmaEmbedPlugin extends Plugin {
         const svg = document.createElementNS(svgNS, "svg");
         svg.setAttribute("viewBox", "0 0 38 57");
         svg.setAttribute("fill", "none");
-        const paths = [
-            { d: "M19 28.5C19 23.2533 23.2533 19 28.5 19C33.7467 19 38 23.2533 38 28.5C38 33.7467 33.7467 38 28.5 38C23.2533 38 19 33.7467 19 28.5Z", fill: "#1ABCFE" },
-            { d: "M0 47.5C0 42.2533 4.25329 38 9.5 38H19V47.5C19 52.7467 14.7467 57 9.5 57C4.25329 57 0 52.7467 0 47.5Z", fill: "#0ACF83" },
-            { d: "M19 0V19H28.5C33.7467 19 38 14.7467 38 9.5C38 4.25329 33.7467 0 28.5 0H19Z", fill: "#FF7262" },
-            { d: "M0 9.5C0 14.7467 4.25329 19 9.5 19H19V0H9.5C4.25329 0 0 4.25329 0 9.5Z", fill: "#F24E1E" },
-            { d: "M0 28.5C0 33.7467 4.25329 38 9.5 38H19V19H9.5C4.25329 19 0 23.2533 0 28.5Z", fill: "#A259FF" },
-        ];
-        for (const p of paths) {
+        for (const p of FIGMA_LOGO_PATHS) {
             const path = document.createElementNS(svgNS, "path");
             path.setAttribute("d", p.d);
             path.setAttribute("fill", p.fill);
@@ -146,7 +159,6 @@ export default class FigmaEmbedPlugin extends Plugin {
         }
         iconDiv.appendChild(svg);
 
-        // Header group: icon + filename + type chip
         const header = document.createElement("div");
         header.classList.add("figmaembed-fallback-header");
         header.appendChild(iconDiv);
@@ -157,7 +169,6 @@ export default class FigmaEmbedPlugin extends Plugin {
         nameDiv.textContent = fileName;
         header.appendChild(nameDiv);
 
-        // File type chip
         const typeDiv = document.createElement("span");
         typeDiv.classList.add("figmaembed-fallback-filetype");
         typeDiv.textContent = fileType;
@@ -165,13 +176,11 @@ export default class FigmaEmbedPlugin extends Plugin {
 
         fallback.appendChild(header);
 
-        // Message
         const msgDiv = document.createElement("div");
         msgDiv.classList.add("figmaembed-fallback-message");
-        msgDiv.textContent = "This file is private. Open it in your browser to view.";
+        msgDiv.textContent = "Unable to load this embed. The file may be private, or the connection timed out.";
         fallback.appendChild(msgDiv);
 
-        // Open button
         const btn = document.createElement("a");
         btn.classList.add("figmaembed-fallback-button");
         btn.href = figmaUrl;
@@ -184,55 +193,21 @@ export default class FigmaEmbedPlugin extends Plugin {
     }
 
     /**
-     * Parse a human-readable file name from a Figma URL.
-     * E.g. "https://www.figma.com/design/abc123/My-Cool-Design?..." -> "My Cool Design"
+     * Parse file info from a Figma URL.
+     * E.g. "https://www.figma.com/design/abc123/My-Cool-Design?..." -> { name: "My Cool Design", type: "Design File" }
      */
-    private parseFigmaFileName(url: string): string {
+    private parseFigmaFileInfo(url: string): { name: string; type: string } {
         try {
-            const pathname = new URL(url).pathname;
-            const segments = pathname.split("/").filter(Boolean);
-            if (segments.length >= 3) {
-                return decodeURIComponent(segments[2]).replace(/-/g, " ");
-            }
-            return "Figma File";
+            const segments = new URL(url).pathname.split("/").filter(Boolean);
+            const name = segments.length >= 3
+                ? decodeURIComponent(segments[2]).replace(/-/g, " ")
+                : "Figma File";
+            const type = FILE_TYPE_MAP[segments[0]] || "Figma File";
+            return { name, type };
         } catch {
-            return "Figma File";
+            return { name: "Figma File", type: "Figma File" };
         }
     }
 
-    /**
-     * Parse the file type from a Figma URL path segment.
-     * E.g. "/design/..." -> "Design File", "/proto/..." -> "Prototype"
-     */
-    private parseFigmaFileType(url: string): string {
-        const typeMap: Record<string, string> = {
-            file: "Design File",
-            design: "Design File",
-            proto: "Prototype",
-            board: "FigJam Board",
-            slides: "Slides",
-            deck: "Slide Deck",
-            buzz: "Buzz",
-            site: "Figma Site",
-        };
-        try {
-            const pathname = new URL(url).pathname;
-            const segments = pathname.split("/").filter(Boolean);
-            if (segments.length >= 1) {
-                return typeMap[segments[0]] || "Figma File";
-            }
-            return "Figma File";
-        } catch {
-            return "Figma File";
-        }
-    }
-
-    onunload() {
-        this.messageHandlers.forEach(handler => {
-            window.removeEventListener("message", handler);
-        });
-        this.messageHandlers = [];
-        this.fallbackTimeouts.forEach(id => clearTimeout(id));
-        this.fallbackTimeouts = [];
-    }
+    onunload() {}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,7 @@ export default class FigmaEmbedPlugin extends Plugin {
      * Parse a human-readable file name from a Figma URL.
      * E.g. "https://www.figma.com/design/abc123/My-Cool-Design?..." -> "My Cool Design"
      */
-    parseFigmaFileName(url: string): string {
+    private parseFigmaFileName(url: string): string {
         try {
             const pathname = new URL(url).pathname;
             const segments = pathname.split("/").filter(Boolean);
@@ -97,7 +97,7 @@ export default class FigmaEmbedPlugin extends Plugin {
      * Parse the file type from a Figma URL path segment.
      * E.g. "/design/..." -> "Design File", "/proto/..." -> "Prototype"
      */
-    parseFigmaFileType(url: string): string {
+    private parseFigmaFileType(url: string): string {
         const typeMap: Record<string, string> = {
             file: "Design File",
             design: "Design File",

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,19 +145,25 @@ export default class FigmaEmbedPlugin extends Plugin {
             svg.appendChild(path);
         }
         iconDiv.appendChild(svg);
-        fallback.appendChild(iconDiv);
+
+        // Header group: icon + filename + type chip
+        const header = document.createElement("div");
+        header.classList.add("figmaembed-fallback-header");
+        header.appendChild(iconDiv);
 
         // File name (textContent — safe from XSS)
         const nameDiv = document.createElement("div");
         nameDiv.classList.add("figmaembed-fallback-filename");
         nameDiv.textContent = fileName;
-        fallback.appendChild(nameDiv);
+        header.appendChild(nameDiv);
 
-        // File type
-        const typeDiv = document.createElement("div");
+        // File type chip
+        const typeDiv = document.createElement("span");
         typeDiv.classList.add("figmaembed-fallback-filetype");
         typeDiv.textContent = fileType;
-        fallback.appendChild(typeDiv);
+        header.appendChild(typeDiv);
+
+        fallback.appendChild(header);
 
         // Message
         const msgDiv = document.createElement("div");

--- a/styles.css
+++ b/styles.css
@@ -11,3 +11,75 @@ If your plugin does not need CSS, delete this file.
 	height: 450px;
 	border: none;
   }
+
+.figmaembed-container {
+    position: relative;
+    width: 100%;
+}
+
+.figmaembed-container .figmaembed-iframe {
+    width: 100%;
+    height: 450px;
+    border: none;
+}
+
+.figmaembed-fallback {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 40px 20px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    background-color: var(--background-secondary);
+    text-align: center;
+}
+
+.figmaembed-fallback.is-visible {
+    display: flex;
+}
+
+.figmaembed-fallback-icon svg {
+    width: 40px;
+    height: 40px;
+}
+
+.figmaembed-fallback-filename {
+    font-size: var(--font-ui-medium);
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.figmaembed-fallback-filetype {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    margin-top: -8px;
+}
+
+.figmaembed-fallback-message {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+    max-width: 300px;
+}
+
+.figmaembed-fallback-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+    font-size: var(--font-ui-small);
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: none;
+    border: none;
+}
+
+.figmaembed-fallback-button:hover {
+    background-color: var(--interactive-accent-hover);
+    text-decoration: none;
+    color: var(--text-on-accent);
+}

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,7 @@ If your plugin does not need CSS, delete this file.
     justify-content: center;
     gap: 16px;
     min-height: 450px;
-    padding: 40px 40px;
+    padding: 40px;
     box-sizing: border-box;
     border: 1px solid var(--background-modifier-border);
     border-radius: 8px;

--- a/styles.css
+++ b/styles.css
@@ -22,8 +22,10 @@ If your plugin does not need CSS, delete this file.
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 12px;
-    padding: 40px 20px;
+    gap: 16px;
+    min-height: 450px;
+    padding: 40px 40px;
+    box-sizing: border-box;
     border: 1px solid var(--background-modifier-border);
     border-radius: 8px;
     background-color: var(--background-secondary);
@@ -35,33 +37,51 @@ If your plugin does not need CSS, delete this file.
 }
 
 .figmaembed-fallback-icon svg {
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
+}
+
+.figmaembed-fallback-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
 }
 
 .figmaembed-fallback-filename {
-    font-size: var(--font-ui-medium);
+    font-size: var(--font-ui-large);
     font-weight: 600;
     color: var(--text-normal);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .figmaembed-fallback-filetype {
-    font-size: var(--font-ui-small);
+    display: inline-block;
+    font-size: var(--font-ui-smaller);
     color: var(--text-muted);
-    margin-top: -8px;
+    background-color: var(--background-modifier-hover);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
 }
 
 .figmaembed-fallback-message {
     font-size: var(--font-ui-small);
-    color: var(--text-muted);
-    max-width: 300px;
+    color: var(--text-faint);
+    max-width: 500px;
+    margin-top: 4px;
 }
 
 .figmaembed-fallback-button {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 16px;
+    padding: 6px 14px;
     border-radius: 6px;
     background-color: var(--interactive-accent);
     color: var(--text-on-accent);
@@ -70,6 +90,7 @@ If your plugin does not need CSS, delete this file.
     cursor: pointer;
     text-decoration: none;
     border: none;
+    margin-top: 4px;
 }
 
 .figmaembed-fallback-button:hover {

--- a/styles.css
+++ b/styles.css
@@ -6,12 +6,6 @@ available in the app when your plugin is enabled.
 If your plugin does not need CSS, delete this file.
 
 */
-.figmaembed-iframe {
-	width: 100%;
-	height: 450px;
-	border: none;
-  }
-
 .figmaembed-container {
     position: relative;
     width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,22 @@
-/*
-
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
-
-If your plugin does not need CSS, delete this file.
-
-*/
 .figmaembed-container {
+    --figmaembed-height: 450px;
     position: relative;
     width: 100%;
 }
 
 .figmaembed-container .figmaembed-iframe {
     width: 100%;
-    height: 450px;
+    height: var(--figmaembed-height);
     border: none;
 }
 
-.figmaembed-fallback {
+.figmaembed-container .figmaembed-fallback {
     display: none;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: 16px;
-    min-height: 450px;
+    min-height: var(--figmaembed-height);
     padding: 40px;
     box-sizing: border-box;
     border: 1px solid var(--background-modifier-border);
@@ -32,23 +25,23 @@ If your plugin does not need CSS, delete this file.
     text-align: center;
 }
 
-.figmaembed-fallback.is-visible {
+.figmaembed-container .figmaembed-fallback.is-visible {
     display: flex;
 }
 
-.figmaembed-fallback-icon svg {
+.figmaembed-container .figmaembed-fallback-icon svg {
     width: 36px;
     height: 36px;
 }
 
-.figmaembed-fallback-header {
+.figmaembed-container .figmaembed-fallback-header {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
 }
 
-.figmaembed-fallback-filename {
+.figmaembed-container .figmaembed-fallback-filename {
     font-size: var(--font-ui-large);
     font-weight: 600;
     color: var(--text-normal);
@@ -58,7 +51,7 @@ If your plugin does not need CSS, delete this file.
     white-space: nowrap;
 }
 
-.figmaembed-fallback-filetype {
+.figmaembed-container .figmaembed-fallback-filetype {
     display: inline-block;
     font-size: var(--font-ui-smaller);
     color: var(--text-muted);
@@ -70,14 +63,14 @@ If your plugin does not need CSS, delete this file.
     letter-spacing: 0.02em;
 }
 
-.figmaembed-fallback-message {
+.figmaembed-container .figmaembed-fallback-message {
     font-size: var(--font-ui-small);
     color: var(--text-faint);
     max-width: 500px;
     margin-top: 4px;
 }
 
-.figmaembed-fallback-button {
+.figmaembed-container .figmaembed-fallback-button {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -93,7 +86,7 @@ If your plugin does not need CSS, delete this file.
     margin-top: 4px;
 }
 
-.figmaembed-fallback-button:hover {
+.figmaembed-container .figmaembed-fallback-button:hover {
     background-color: var(--interactive-accent-hover);
     text-decoration: none;
     color: var(--text-on-accent);


### PR DESCRIPTION
## Summary
Enhances a user's experience when trying to load a locked or private file.

**Reasoning**
From what I can tell, Figma's embed endpoint (/embed?embed_host=...&url=...) uses session cookies exclusively for authentication. There is no way to pass a token, API key, or OAuth credential via the embed URL or headers. This limitation is inherent to the Figma platform and cannot be circumvented on the plugin side.

The core issue is that Obsidian's iframe has its own isolated cookie jar, separate from your browser. Therefore, even if you click "Log in" inside the embed, the authentication occurs in a different context, and the cookies do not return to the iframe. Figma's documentation states that embeds are not supported in native or desktop applications for this reason.

Tools like Notion and Confluence face the same limitation; each viewer must already be logged into Figma in their browser session. Some third-party tools, such as Collabsoft for Confluence, work around this by using a server-side proxy that authenticates with Figma and caches rendered content. However, this solution is not viable for a local-first Obsidian plugin.

The Figma REST API does support token-based authentication for fetching static thumbnails, but those image URLs expire after approximately 30 days and are publicly accessible. This means anyone with the URL can view them, which raises its own security concerns.

Given these constraints, the fallback card approach provides the best user experience. The plugin detects when an embed fails to load, hides the broken iframe, and displays a clean card with the file name, file type, and a button to open it directly in Figma.


| Previous | New |
|--------|--------|
| <img width="1320" height="1262" alt="CleanShot 2026-03-08 at 06 45 30@2x" src="https://github.com/user-attachments/assets/e05f869a-aa09-466c-8c34-1002559cccec" /> | <img width="1520" height="1228" alt="CleanShot 2026-03-08 at 06 42 02@2x" src="https://github.com/user-attachments/assets/e0679244-e458-4ba8-a8aa-8dfc65829422" /> |


- When a private/locked Figma file embed fails to load, the plugin now shows a styled fallback card instead of a broken login screen
- Listens for Figma's `postMessage` events to detect success (`INITIAL_LOAD`) or login required (`LOGIN_SCREEN_SHOWN`), with a 5-second timeout safety net
- Fallback card displays Figma logo, parsed file name, file type chip (Design File, Prototype, FigJam Board, etc.), a private file message, and an "Open in Figma" button
- Styled with Obsidian CSS variables — adapts to light mode, dark mode, and custom themes
- Uses safe DOM methods (no innerHTML) to prevent XSS
- Per-iframe message scoping prevents cross-talk when multiple embeds are on one page
- Properly cleans up event listeners and timeouts on plugin unload

## Test plan

- [x] Paste a public Figma link — iframe should load normally, no fallback card
- [x] Paste a private Figma link — fallback card appears with file name, type chip, and "Open in Figma" button
- [x] Test in light mode, dark mode, and a custom theme
- [x] Test with multiple Figma links on one page (mix of public/private)
- [x] Verify "Open in Figma" button opens the correct URL in browser